### PR TITLE
Support jars, qr & label customization

### DIFF
--- a/config.edn.example
+++ b/config.edn.example
@@ -1,0 +1,8 @@
+{:token           ""
+ :account         ""
+ :start-balance   0
+ :target-balance  100
+ :since           "2022-06-14T10:35:24.00Z"
+ :webhook         "https://1111-111-11-111-11.ngrok.io/webhook"
+ :donate-url      "https://fwdays.com/event/stream-zaharchenko#donate"
+ :donate-label    "допоможи ЗСУ"}

--- a/monofetch.clj
+++ b/monofetch.clj
@@ -349,7 +349,7 @@ strong {color: white}
               logo ;; Державний герб України
 
               [:span.ml-1.shadow
-               "Скануй та " [:br] "допоможи ЗСУ"]]
+               "Скануй та " [:br] (:donate-label (config) "допоможи ЗСУ")]]
 
              (progress-bar)
 

--- a/monofetch.clj
+++ b/monofetch.clj
@@ -113,7 +113,8 @@
 
 (defn update-info! []
   (let [account    (:account (config))
-        accs       (->> (:accounts (req! :get "/personal/client-info"))
+        resp       (req! :get "/personal/client-info")
+        accs       (->> (concat (:accounts resp) (:jars resp))
                         (filter #(= (:id %) account)))
         last-tx    (o! {:from   [:tx]
                         :select [[(sql/call :max :updated_at) :updated_at]]})

--- a/monofetch.clj
+++ b/monofetch.clj
@@ -169,7 +169,8 @@
 
 (defn get-stats []
   (let [info     (o! {:from   [:info]
-                      :select [:balance]
+                      :select [:balance
+                               :send_id]
                       :where  [:= :account (:account (config))]})
         target   (:target-balance (config))
         maxvalue (o! {:from     [:tx]
@@ -187,6 +188,7 @@
                                [:= :account (:account (config))]
                                [:> :amount 0]]})]
     {:balance (:balance info)
+     :sendid  (:send_id info)
      :target  target
      :avg     (Math/round (:amount avgvalue))
      :max     (:amount maxvalue)
@@ -216,14 +218,14 @@
        :clip-rule "evenodd",
        :fill-rule "evenodd"}]]))
 
-(def qr
+(defn qr [sendid]
   (hi/html
     [:img {:style {:width "100%"}
            :src   (str "https://chart.googleapis.com/chart?"
                     (codec/form-encode
                       {:cht  "qr"
                        :chs  "200x200"
-                       :chl  "https://fwdays.com/event/stream-zaharchenko#donate"
+                       :chl  (:donate-url (config) (format "https://send.monobank.ua/%s" sendid))
                        :chld "M|2"}))}]))
 
 
@@ -339,7 +341,7 @@ strong {color: white}
                               :width         "6.86em"
                               :border-radius "0.57em"
                               :background    "white"}}
-             qr]
+             (qr (:sendid stats))]
 
 
             [:div.flex.justify-between.grow


### PR DESCRIPTION
Thanks for the project and the stream!
I was thinking about a customizable project that helps people to fund raise these days. 

Changes:
1. Add support for jars.
2. QR code points by default to https://send.monobank.ua/send_id. So having only `account` in `.config.edn` is enough to have a valid donation QR code. Could be customized to put a custom url.
3. Label near QR code could be customized from config.
4. Add `config.edn.example` so there's no need to search through code for environment variables.
5. Mono API calls /webhook during a setup process without body and expects a 200 response.