### PR TITLE
Notify about donations via telegram bot

### DIFF
--- a/config.edn.example
+++ b/config.edn.example
@@ -9,6 +9,10 @@
           ;; тут у форматі метабейзу, тільда в кінці значить "від цієї
           ;; дати і далі"
           :date nil #_ "2022-06-01~"}
+ :telegram {:token nil #_ "bot-token" ; `nil` - не чіпати телеграм
+            ;; token взяти у https://t.me/botfather
+            ;; chat взяти у браузері https://web.telegram.org/z/#-12312312 
+            :chat nil #_ "chat-id"}
 
  :db             "store.db"
  :target-balance 100000 ; у гривнях

--- a/config.edn.example
+++ b/config.edn.example
@@ -13,7 +13,9 @@
             ;; token взяти у https://t.me/botfather
             ;; chat взяти у браузері https://web.telegram.org/z/#-12312312 
             ;; додати бот у цей чат, щоб він міг туди писати
-            :chat nil #_ "-12312312"}
+            :chat nil #_ "-12312312"
+            ;; true, щоб включати donate-url у кожне повідомлення
+            :include-donate-url nil}
 
  :db             "store.db"
  :target-balance 100000 ; у гривнях

--- a/config.edn.example
+++ b/config.edn.example
@@ -12,7 +12,8 @@
  :telegram {:token nil #_ "bot-token" ; `nil` - не чіпати телеграм
             ;; token взяти у https://t.me/botfather
             ;; chat взяти у браузері https://web.telegram.org/z/#-12312312 
-            :chat nil #_ "chat-id"}
+            ;; додати бот у цей чат, щоб він міг туди писати
+            :chat nil #_ "-12312312"}
 
  :db             "store.db"
  :target-balance 100000 ; у гривнях

--- a/donate.clj
+++ b/donate.clj
@@ -173,9 +173,12 @@
 
 
 (defn telegram! [token chat tx]
-  (let [full  (str "https://api.telegram.org/bot" token
+  (let [stats (str (t "Зібрано ")
+                   (human-n (:balance tx)) " ₴"
+                   " / " (human-n (:target-balance (config))) " ₴")
+        full  (str "https://api.telegram.org/bot" token
                    "/sendMessage?chat_id=" chat
-                   "&text=" (codec/form-encode (format "+ %d₴" (long (:amount tx)))))
+                   "&text=" (codec/form-encode (format "+ %d₴\n%s" (long (:amount tx)) stats)))
         res  @(http/request
                 {:method  :post
                  :url     full


### PR DESCRIPTION
Add support to notify about donations via telegram bot.

Behavior is not changed, unless `token` and `chat` specified in config.

Both `mono` and `pzh` flows supported.
For `mono` transactions from webhook are used.
For `pzh` all new transactions that have not yet been persisted to db are used.

Including url to donate in message is optional.

#### Examples
![Screenshot from 2022-06-23 19-41-39](https://user-images.githubusercontent.com/729374/175351878-17645738-51af-498b-bcb1-1db33b6b2300.png)
![Screenshot from 2022-06-23 19-45-02](https://user-images.githubusercontent.com/729374/175351772-1d3e5007-0aa5-43f7-9414-136a3cc2a037.png)
